### PR TITLE
Update README.md fixing Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ Main programming languages: Python, C#, C++ </br>
 
 </br>
 </br>
-I am using [github-readme-stats](https://www.github.com/anuraghazra/github-readme-stats/) for the awesome github stats. </br>
+
+I am using [github-readme-stats](https://www.github.com/anuraghazra/github-readme-stats/) for the awesome github stats.
 I am using [Blog post workflow](https://www.github.com/gautamkrishnar/blog-post-workflow/) for the awesome always up-to date feed(s).


### PR DESCRIPTION
Hi,

I noticed earlier the Markdown syntax displayed in your profile page.

This PR removes the HTML from the line with Markdown, so that GH renders the markdown correctly :+1: 

Bruno